### PR TITLE
Add Redis publish in case of new update

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -28,7 +28,7 @@ dependencies = [
 
 [[package]]
 name = "ambrogio_bin"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "ambrogio_core",
  "ambrogio_users",


### PR DESCRIPTION
Trying to solve #39.

---

How it works:
- `ambrog.io` is supposed to be run in a container through `docker-compose` in a server
- `ambrog.io` listens to the ngrok websocket
- `ambrog.io` publishes a message to redis for the version
- the runner of `ambrog.io` listens to such redis topic and forces the reboot of ambrogio
  - more info: this listener is implemented through a systemd service that executes [this loop](https://stackoverflow.com/a/66103101)