### PR TITLE
Handle impossible date error

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -28,7 +28,7 @@ dependencies = [
 
 [[package]]
 name = "ambrogio_bin"
-version = "0.8.3"
+version = "0.8.4"
 dependencies = [
  "ambrogio_core",
  "ambrogio_users",

--- a/open_meteo/src/lib.rs
+++ b/open_meteo/src/lib.rs
@@ -242,6 +242,10 @@ impl TryFrom<(Forecast, Geolocalisation)> for Meteo {
                 // This is due to the fact that daylight saving time happens at that moment.
                 // Time is moved back 1h => we have 1h "overlap" between the two different time offsets (+2 and +1)
                 Err(parse) if parse.kind().eq(&ParseErrorKind::NotEnough) => continue,
+                // (2023-03-31T02:00): input is not possible for date and time
+                // This is due to the fact that daylight saving time happens at that moment.
+                // Time is moved forward 1h => we have 1h void between 2AM and 3AM
+                Err(parse) if parse.kind().eq(&ParseErrorKind::Impossible) => continue,
                 d => d,
             };
             let point = Weather {


### PR DESCRIPTION
This happens when trying to deserialise impossible dates like 2024-03-31T02:00. This is due daylight saving that moves the clock 1h forward from 2AM to 3AM. Everything between 2AM and 3AM (non inclusive end) doesn't exist.