### PR TITLE
Enforce apt update before upgrading dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -41,7 +41,7 @@ dependencies = [
 
 [[package]]
 name = "ambrogio_bin"
-version = "0.9.3"
+version = "0.10.0"
 dependencies = [
  "ambrogio_core",
  "ambrogio_reminders",

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,4 +18,4 @@ ARG app_version=unknown
 ENV APP_VERSION=${app_version}
 
 # Enforce upgrades
-ENTRYPOINT ["/bin/sh", "-c" , "apt install -y --only-upgrade ffmpeg yt-dlp && /workdir/ambrogio"]
+ENTRYPOINT ["/bin/sh", "-c" , "apt update --fix-missing && apt install -y --only-upgrade ffmpeg yt-dlp && /workdir/ambrogio"]


### PR DESCRIPTION
This should enforce Ambrogio to fetch at container restart